### PR TITLE
Feature/005 add props

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,8 @@
   <div id="app">
     <!-- <hello></hello> -->
 
-    <anchor-link href="https://github.com/soregashi-27" text="Link to Soregashi27's GitHub Page"></anchor-link>
+    <anchor-link href="https://github.com/soregashi-27" text="Link to Soregashi27's GitHub Page" :new-tab="false">
+    </anchor-link>
   </div>
   <script src="/bundle.js"></script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,9 @@
 
 <body>
   <div id="app">
-    <hello></hello>
+    <!-- <hello></hello> -->
+
+    <anchor-link href="https://github.com/soregashi-27" text="Link to Soregashi27's GitHub Page"></anchor-link>
   </div>
   <script src="/bundle.js"></script>
 </body>

--- a/src/components/AnchorLink.vue
+++ b/src/components/AnchorLink.vue
@@ -5,12 +5,26 @@
 <script>
 export default {
   props: {
-    text: String,
-    href: String
+    text: {
+      type: String,
+      required: true
+    },
+    href: {
+      type: String,
+      required: true
+    },
+    newTab: {
+      type: Boolean,
+      default: false
+    }
   },
   methods: {
     onClickLink() {
-      window.location.href = this.href
+      if (this.newTab === true) {
+        window.open(this.href, '_blank')
+      } else {
+        window.location.href = this.href
+      }
     }
   }
 }

--- a/src/components/AnchorLink.vue
+++ b/src/components/AnchorLink.vue
@@ -1,0 +1,25 @@
+<template>
+  <span class="anchor" @click="onClickLink">{{ text }}</span>
+</template>
+
+<script>
+export default {
+  props: {
+    text: String,
+    href: String
+  },
+  methods: {
+    onClickLink() {
+      window.location.href = this.href
+    }
+  }
+}
+</script>
+
+<style scoped>
+.anchor {
+  color: blue;
+  cursor: pointer;
+  text-decoration: underline;
+}
+</style>

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import Vue from 'vue'
-import Hello from './components/Hello.vue'
+// import Hello from './components/Hello.vue' //componentsの動き用に追加
+
+import AnchorLink from './components/AnchorLink.vue'
 
 new Vue({
   el: '#app',
   components: {
-    hello: Hello
+    AnchorLink
   }
 })


### PR DESCRIPTION
Vue.jsの設計思想として、`props` の定義をできる限り詳細に書くことが「必須」とされてる。

HTML ファイル内では Vue コンポーネントのタグ名はケバブケースで記述すること

htmlだと大文字、小文字は認識できないのでハイフンを使って表すのも設計思想の一つ。

